### PR TITLE
FIX: JobTag 관련 내용 수정(회원가입, 마이페이지, Enum)

### DIFF
--- a/src/main/java/com/example/sokdak/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/sokdak/user/dto/SignupRequestDto.java
@@ -21,9 +21,9 @@ public class SignupRequestDto {
     @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9)이어야 합니다.")
     private String password;
 
-    private int jobTag;
+    private int jobTag = 999;
 
-    private int careerTag;
+    private int careerTag = 999;
 
     private boolean admin = false;
 

--- a/src/main/java/com/example/sokdak/user/entity/CareerTag.java
+++ b/src/main/java/com/example/sokdak/user/entity/CareerTag.java
@@ -20,7 +20,8 @@ public enum CareerTag {
     Tag_7(7, "7년차 이상"),
     Tag_8(8, "8년차 이상"),
     Tag_9(9, "9년차 이상"),
-    Tag_10(10, "10년차 이상");
+    Tag_10(10, "10년차 이상"),
+    Tag_999(999,"경력 미설정");
 
     private final int careerTag;
     private final String tagMsg;

--- a/src/main/java/com/example/sokdak/user/entity/JobTag.java
+++ b/src/main/java/com/example/sokdak/user/entity/JobTag.java
@@ -15,7 +15,8 @@ public enum JobTag {
     앱개발자(3, "앱 개발자"),
     게임개발자(4, "게임 개발자"),
     QA(5, "QA"),
-    DevOps(6, "DevOps");
+    DevOps(6, "DevOps"),
+    미설정(999, "직군 미설정");
 
     private final int jobTag;
     private final String TagMsg;

--- a/src/main/java/com/example/sokdak/user/entity/User.java
+++ b/src/main/java/com/example/sokdak/user/entity/User.java
@@ -29,10 +29,10 @@ public class User {
     private String profileImage;                            // 프로필 사진 Url (S3 Path)
 
     @Column(nullable = true)
-    private String jobTag;                                  // 직업 태그 ( 0 : 웹개발자, 1 : 서버 개발자, 2: 프론트앤드 개발자, 3: QA 테스트엔지니어, 4: DevOps/시스템관리자)
+    private String jobTag = null;                                  // 직업 태그 ( 0 : 웹개발자, 1 : 서버 개발자, 2: 프론트앤드 개발자, 3: QA 테스트엔지니어, 4: DevOps/시스템관리자)
 
     @Column(nullable = true)
-    private String careerTag;                               // 경력 태그 ( 0 : 신입, 1: 1년 이상 , ... , 10 : 10년 이상)
+    private String careerTag = null;                               // 경력 태그 ( 0 : 신입, 1: 1년 이상 , ... , 10 : 10년 이상)
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/example/sokdak/user/service/UserService.java
+++ b/src/main/java/com/example/sokdak/user/service/UserService.java
@@ -42,7 +42,6 @@ public class UserService {
     public MsgResponseDto signup(SignupRequestDto signupRequestDto) {
 
         String nickname = RandomStringUtils.random(15, true, true);                         // 닉네임 랜덤 생성
-
         String userId = signupRequestDto.getUserId();
         String password = passwordEncoder.encode(signupRequestDto.getPassword());
         String jobTag = JobTag.valueOfJobTag(signupRequestDto.getJobTag()).getTagMsg();                         // jobTag Enum에서 입력받은 int value와  일치하는 String 값 반환


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/mypage > developer

### 변경 사항
- 기존 : 회원가입시 Job/CareerTag를 선택할 수 없는 카카오 유저의 경우 오류가 발생함 
- 변경 : 회원가입시  Job/CareerTag를 입력하지않으면, 999로 넣음(직군 미선택/경력 미선택)

### 테스트 결과
Postman 테스트 결과 이상 없습니다.