### PR TITLE
FIX : 게시글 출력시 댓글에 userTag,nickname이 출력되게 수정

### DIFF
--- a/src/main/java/com/example/sokdak/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/sokdak/comment/dto/CommentResponseDto.java
@@ -2,6 +2,8 @@ package com.example.sokdak.comment.dto;
 
 
 import com.example.sokdak.comment.entity.Comment;
+import com.example.sokdak.user.entity.CareerTag;
+import com.example.sokdak.user.entity.JobTag;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
@@ -11,30 +13,35 @@ import java.time.LocalDateTime;
 public class CommentResponseDto {
     private Long commentId;
     private Long boardId;
-    private String userId;
+    private String nickname;
     private String comment;
-    private LocalDateTime modifiedat;
-    private LocalDateTime createdat;
-
+    private int userCareerTag;
+    private int userJobTag;
+    private LocalDateTime modifiedAt;
+    private LocalDateTime createdAt;
     private Boolean commentIscorrect;
 
     //생성자
     public CommentResponseDto(Comment comment) {
         this.boardId = comment.getBoard().getId();
         this.commentId = comment.getId();
-        this.userId = comment.getUserId();
+        this.nickname = comment.getUser().getNickname();
+        this.userCareerTag = CareerTag.valueOfCareerTag(comment.getUser().getCareerTag()).getCareerTag();
+        this.userJobTag = JobTag.valueOfJobTag(comment.getUser().getJobTag()).getJobTag();
         this.comment = comment.getContent();
-        this.modifiedat = comment.getModifiedAt();
-        this.createdat = comment.getModifiedAt();
+        this.modifiedAt = comment.getModifiedAt();
+        this.createdAt = comment.getModifiedAt();
     }
 
     public CommentResponseDto(Comment comment, Boolean commentIscorrect) {
         this.boardId = comment.getBoard().getId();
         this.commentId = comment.getId();
-        this.userId = comment.getUserId();
+        this.nickname = comment.getUser().getNickname();
+        this.userCareerTag = CareerTag.valueOfCareerTag(comment.getUser().getCareerTag()).getCareerTag();
+        this.userJobTag = JobTag.valueOfJobTag(comment.getUser().getJobTag()).getJobTag();
         this.comment = comment.getContent();
-        this.modifiedat = comment.getModifiedAt();
-        this.createdat = comment.getModifiedAt();
+        this.modifiedAt = comment.getModifiedAt();
+        this.createdAt = comment.getModifiedAt();
         this.commentIscorrect = commentIscorrect;
     }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/board-> develop

### 변경 사항
- 게시글 출력시 댓글에 userTag,nickname이 출력되게 수정

### 테스트 결과
Postman 테스트 결과 이상 없습니다.